### PR TITLE
feat: BE: Send basic info submitted flag to ADP connector from WS Backend [WS-25563]

### DIFF
--- a/packages/sdk-ruby/src/workstream_protocol/lib/workstream_protocol/Onboarding_pb.rb
+++ b/packages/sdk-ruby/src/workstream_protocol/lib/workstream_protocol/Onboarding_pb.rb
@@ -102,6 +102,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :job_title, :string, 56
     optional :department_name, :string, 57
     optional :hire_location_id, :string, 58
+    optional :basic_info_module_submitted, :bool, 59
   end
   add_message "Workstream.Protocol.Onboarding.EmployeeInitialStateEvent" do
     optional :id, :string, 1

--- a/packages/sdk-ruby/src/workstream_protocol/lib/workstream_protocol/version.rb
+++ b/packages/sdk-ruby/src/workstream_protocol/lib/workstream_protocol/version.rb
@@ -1,3 +1,3 @@
 module WorkstreamProtocol
-  VERSION = "0.7.2"
+  VERSION = "0.7.3"
 end

--- a/src/Onboarding.proto
+++ b/src/Onboarding.proto
@@ -140,6 +140,9 @@ message EmployeeInformationEvent {
   string job_title =56;
   string department_name =57;
   string hire_location_id =58;
+
+  // Basic Information flag
+  bool basic_info_module_submitted =59;
 }
 
 message EmployeeInitialStateEvent {


### PR DESCRIPTION
 - Added a flag in employee information message that tells if basic info module is submitted or not